### PR TITLE
attach subjects to posts

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,3 +1,5 @@
+from django.shortcuts import get_object_or_404
+
 from rest_framework import serializers
 from rest_framework.request import Request
 
@@ -36,6 +38,18 @@ class SubjectSerializer(serializers.ModelSerializer):
             'name',
             'course',
         ]
+
+    def to_internal_value(self, data):
+        """
+        Needed for PostSerializer create posts passing only the Subject id.
+        Otherwise every time a Post is created a new Subject is alse created.
+        """
+        if isinstance(data, int):
+            return get_object_or_404(Subject.objects.all(), pk=data)
+        elif isinstance(data, dict) and data.get('id'):
+            return get_object_or_404(Subject.objects.all(), pk=data.get('id'))
+
+        return super(SubjectSerializer, self).to_internal_value(data)
 
 
 class StudentSerializer(serializers.ModelSerializer):
@@ -80,6 +94,7 @@ class TagSerializer(serializers.ModelSerializer):
 
 
 class PostSerializer(serializers.ModelSerializer):
+    subject = SubjectSerializer()
     tag = TagSerializer(many=True, read_only=True)
 
     class Meta:

--- a/api/tests/post_viewset_test.py
+++ b/api/tests/post_viewset_test.py
@@ -78,7 +78,7 @@ class PostTestCase(APITestCase, TestCheckMixin):
 
         self.assertEqual(201, response.status_code)
         self.assertEqual(data["author"], response.data['author'])
-        self.assertEqual(data["subject"], response.data['subject'])
+        self.assertEqual(data["subject"], response.data['subject']['id'])
         self.assertEqual(data["emotion"], response.data['emotion'])
 
     def test_user_update_posts(self):

--- a/api/views/post_views.py
+++ b/api/views/post_views.py
@@ -32,7 +32,11 @@ class PostViewSet(ModelViewSet):
                 {
                     "id": 1,
                     "author": 1,
-                    "subject": 15,
+                    "subject": {
+                        "id": 15,
+                        "name": "Calculo 1",
+                        "course": 1
+                    },
                     "tag": [
                         {
                             "id": 1,
@@ -63,7 +67,7 @@ class PostViewSet(ModelViewSet):
             "results": [
                 {
                     "author": pedro_1195@hotmail.com,
-                    "subject": COMBUSTIVEIS E BIOCOMBUSTIVEIS,
+                    "subject": 1,
                     "tag": [
                             {
                                 "id": 1,
@@ -87,7 +91,11 @@ class PostViewSet(ModelViewSet):
                 {
                     "id": 2,
                     "author": 1,
-                    "subject": 11,
+                    "subject": {
+                        "id": 1,
+                        "name": "Calculo 1",
+                        "course": 1
+                    },
                     "tag": [
                             {
                                 "id": 1,
@@ -126,7 +134,11 @@ class PostViewSet(ModelViewSet):
                 {
                     "id": 1,
                     "author": 1,
-                    "subject": 15,
+                     "subject": {
+                        "id": 15,
+                        "name": "Calculo 1",
+                        "course": 1
+                    },
                     "tag": [
                             {
                                 "id": 1,
@@ -165,14 +177,18 @@ class PostViewSet(ModelViewSet):
                     "id": 1,
                     "author": 1,
                     "content": "Melhor aula do mundo",
-                    "subject": 15,
+                     "subject": {
+                        "id": 15,
+                        "name": "Calculo 1",
+                        "course": 1
+                    },
                     "tag": [
                             {
                                 "id": 1,
                                 "description": "TAG1",
                                 "quantity": 2
                             }
-                    ],           
+                    ],
                     "emotion": "g",
                     "created_at": "2018-05-23T00:20:22.344509Z"
                 }
@@ -199,7 +215,11 @@ class PostViewSet(ModelViewSet):
                 {
                     "author": hpedro1195@gmail.com,
                     "content": "Pior aula do mundo",
-                    "subject": 15,
+                     "subject": {
+                        "id": 15,
+                        "name": "Calculo 1",
+                        "course": 1
+                    },
                     "tag": [
                             {
                                 "id": 1,
@@ -212,7 +232,7 @@ class PostViewSet(ModelViewSet):
                 }
               ]
           }
-    
+
         ```
         Response example:
         ```
@@ -225,7 +245,11 @@ class PostViewSet(ModelViewSet):
                     "id": 1,
                     "author": hpedro1195@gmail.com,
                     "content": "Pior aula do mundo",
-                    "subject": 15,
+                     "subject": {
+                        "id": 15,
+                        "name": "Calculo 1",
+                        "course": 1
+                    },
                     "tag": [
                             {
                                 "id": 1,
@@ -256,7 +280,7 @@ class PostViewSet(ModelViewSet):
         ---
         Response example:
         ```
-        
+
           {
             "count": 1,
             "next": null,
@@ -266,7 +290,11 @@ class PostViewSet(ModelViewSet):
                     "id": 1,
                     "author": hpedro1195@gmail.com,
                     "content": "Pior aula do mundo",
-                    "subject": 15,
+                     "subject": {
+                        "id": 15,
+                        "name": "Calculo 1",
+                        "course": 1
+                    },
                     "tag": [
                             {
                                 "id": 1,
@@ -279,7 +307,7 @@ class PostViewSet(ModelViewSet):
                 }
             ]
           }
-        
+
         ```
         """
         user = get_object_or_404(Student, pk=user_id)
@@ -299,7 +327,7 @@ class PostViewSet(ModelViewSet):
 
             data.is_valid()
             return Response(data.data)
-            
+
     @list_route(
         permission_classes=[],
         methods=['GET'],
@@ -309,7 +337,7 @@ class PostViewSet(ModelViewSet):
         API endpoint that getts the posts of a given subject
         ---
         Response example:
-        ``` 
+        ```
           {
             "count": 1,
             "next": null,
@@ -318,7 +346,11 @@ class PostViewSet(ModelViewSet):
                 {
                     "id": 1,
                     "author": hpedro1195@gmail.com,
-                    "subject": 15,
+                     "subject": {
+                        "id": 15,
+                        "name": "Calculo 1",
+                        "course": 1
+                    },
                     "tag": [
                             {
                                 "id": 1,
@@ -331,7 +363,7 @@ class PostViewSet(ModelViewSet):
                 }
             ]
           }
-    
+
         ```
         """
         subject = get_object_or_404(Subject, pk=subject_id)
@@ -358,7 +390,8 @@ class PostViewSet(ModelViewSet):
         url_path='subjects_posts_count')
     def subjects_posts(self, request):
         """
-        Returns posts's emotion counting for all subjects that have at least one post about it
+        Returns posts's emotion counting for all subjects that have at least
+        one post about it
         ---
         Response example:
         ```
@@ -372,17 +405,16 @@ class PostViewSet(ModelViewSet):
         ```
         """
 
-        from datetime import datetime
-        print('calling subject_posts view at {}'.format(datetime.now()))
-
         subjects_emotions_count_list = []
         for subject in Subject.objects.all():
             emotion_count = get_subject_emotions_count(subject)
             if not emotion_count.empty():
                 subjects_emotions_count_list.append(emotion_count)
 
-        serializer = SubjectEmotionsCountSerializer(subjects_emotions_count_list, many=True)
+        serializer = SubjectEmotionsCountSerializer(
+            subjects_emotions_count_list, many=True)
         return Response(serializer.data)
+
 
 def get_subject_emotions_count(subject):
     assert isinstance(subject, Subject)
@@ -399,8 +431,7 @@ def get_subject_emotions_count(subject):
         if emotion not in count:
             count[emotion] = 0
 
-    subject_emotions_count = SubjectEmotionsCount(subject.name,
-                            good_count=count['g'], bad_count=count['b'])
+    subject_emotions_count = SubjectEmotionsCount(
+        subject.name, good_count=count['g'], bad_count=count['b'])
 
     return subject_emotions_count
-


### PR DESCRIPTION
Now posts request and diagnosis will properly display its subjects content.

**Why ?**
Because on the front every time we fetched posts we also have to fetch subjects and filter then by the
posts subject_id.
So for a better performance on the front now posts carry its subject data, no need for fetch subject and filter then any more.
